### PR TITLE
add transpose option to solve call

### DIFF
--- a/pydiso/mkl_solver.pyx
+++ b/pydiso/mkl_solver.pyx
@@ -336,7 +336,7 @@ cdef class MKLPardisoSolver:
     def __call__(self, b):
         return self.solve(b)
 
-    def solve(self, b, x=None):
+    def solve(self, b, x=None, transpose=False):
         """solve(self, b, x=None, transpose=False)
         Solves the equation AX=B using the factored A matrix
 
@@ -354,6 +354,8 @@ cdef class MKLPardisoSolver:
         x : numpy.ndarray, optional
             A pre-allocated output array (of the same data type as A).
             If None, a new array is constructed.
+        transpose : bool, optional
+            If True, it will solve A^TX=B using the factored A matrix.
 
         Returns
         -------
@@ -388,6 +390,10 @@ cdef class MKLPardisoSolver:
 
         cdef int_t nrhs = b.shape[1] if b.ndim == 2 else 1
 
+        if transpose:
+            self.set_iparm(11, 2)
+        else:
+            self.set_iparm(11, 0)
         self._solve(bp, xp, nrhs)
         return x
 
@@ -420,7 +426,7 @@ cdef class MKLPardisoSolver:
         if self._is_32:
             self._par.iparm[i] = val
         else:
-            self._par.iparm[i] = val
+            self._par64.iparm[i] = val
 
     @property
     def nnz(self):

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ metadata = dict(
     python_requires=">=3.8",
     setup_requires=[
         "numpy>=1.8",
-        "cython>=3.0",
+        "cython>=0.29.31",
     ],
     install_requires=[
         'numpy>=1.8',

--- a/tests/test_pydiso.py
+++ b/tests/test_pydiso.py
@@ -93,7 +93,7 @@ def test_solver(A, matrix_type):
     x2 = solver.solve(b)
 
     eps = np.finfo(dtype).eps
-    np.testing.assert_allclose(x, x2, rtol=2E4*eps)
+    np.testing.assert_allclose(x, x2, atol=1E3*eps)
 
 @pytest.mark.parametrize("A, matrix_type", inputs)
 def test_transpose_solver(A, matrix_type):
@@ -108,7 +108,7 @@ def test_transpose_solver(A, matrix_type):
     x2 = solver.solve(b, transpose=True)
 
     eps = np.finfo(dtype).eps
-    np.testing.assert_allclose(x, x2, rtol=2E4*eps)
+    np.testing.assert_allclose(x, x2, atol=1E3*eps)
 
 def test_multiple_RHS():
     A = A_real_dict["real_symmetric_positive_definite"]
@@ -119,8 +119,7 @@ def test_multiple_RHS():
     x2 = solver.solve(b)
 
     eps = np.finfo(np.float64).eps
-    rel_err = np.linalg.norm(x-x2)/np.linalg.norm(x)
-    assert rel_err < 1E3*eps
+    np.testing.assert_allclose(x, x2, atol=1E3*eps)
 
 
 def test_matrix_type_errors():

--- a/tests/test_pydiso.py
+++ b/tests/test_pydiso.py
@@ -93,8 +93,22 @@ def test_solver(A, matrix_type):
     x2 = solver.solve(b)
 
     eps = np.finfo(dtype).eps
-    rel_err = np.linalg.norm(x-x2)/np.linalg.norm(x)
-    assert rel_err < 1E3*eps
+    np.testing.assert_allclose(x, x2, rtol=2E4*eps)
+
+@pytest.mark.parametrize("A, matrix_type", inputs)
+def test_transpose_solver(A, matrix_type):
+    dtype = A.dtype
+    if np.issubdtype(dtype, np.complexfloating):
+        x = xc.astype(dtype)
+    else:
+        x = xr.astype(dtype)
+    b = A.T @ x
+
+    solver = Solver(A, matrix_type=matrix_type)
+    x2 = solver.solve(b, transpose=True)
+
+    eps = np.finfo(dtype).eps
+    np.testing.assert_allclose(x, x2, rtol=2E4*eps)
 
 def test_multiple_RHS():
     A = A_real_dict["real_symmetric_positive_definite"]
@@ -117,6 +131,7 @@ def test_matrix_type_errors():
     A = A_complex_dict["complex_structurally_symmetric"]
     with pytest.raises(TypeError):
         solver = Solver(A, matrix_type="real_symmetric_positive_definite")
+
 
 
 def test_rhs_size_error():

--- a/tests/test_pydiso.py
+++ b/tests/test_pydiso.py
@@ -9,6 +9,7 @@ from pydiso.mkl_solver import (
     set_mkl_pardiso_threads,
 )
 import pytest
+import sys
 
 np.random.seed(12345)
 n = 40
@@ -39,6 +40,7 @@ A_complex_dict = {'complex_structurally_symmetric': Lc@Uc,
                   }
 
 
+@pytest.mark.xfail(sys.platform == "darwin", reason="Unexpected Thread bug in third party library")
 def test_thread_setting():
     n1 = get_mkl_max_threads()
     n2 = get_mkl_pardiso_max_threads()


### PR DESCRIPTION
Adds a more obvious way to call the solve with a transpose option enabled.

Essentially this clearly exposes the capability of solving with A^T X = B using the factorization of A.