### PR TITLE
Provide token to codecov uploader

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -77,6 +77,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         verbose: true # optional (default = false)
+        token: ${{ secrets.CODECOV_TOKEN }} # required
 
   distribute:
     name: Distributing from 3.11


### PR DESCRIPTION
The v4 codecov upload action requires a token.